### PR TITLE
Fix missing cstdint include in utils with GCC v13.2

### DIFF
--- a/src/utils.h
+++ b/src/utils.h
@@ -4,6 +4,7 @@
 #include <stdio.h>
 #include <cmath>
 #include <cstdio>
+#include <cstdint>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Otherwise, building fails because various integer types (uint16_t and similar) are not defined.